### PR TITLE
Updated CDK version to address unsupported NodeJS dependency resource handler

### DIFF
--- a/source/lib/state-machine-construct.ts
+++ b/source/lib/state-machine-construct.ts
@@ -59,7 +59,7 @@ export class InvoiceStateMachine extends Construct {
           "/../packages/checkTextractJobStatus/index.ts"
         ),
         memorySize: 512,
-        runtime: Runtime.NODEJS_18_X,
+        runtime: Runtime.NODEJS_20_X,
         environmentEncryption: new Key(
           this,
           "CheckTextractJobStatusFunctionKey",
@@ -94,7 +94,7 @@ export class InvoiceStateMachine extends Construct {
           "/../packages/invoicePostProcessing/index.ts"
         ),
         memorySize: 1024,
-        runtime: Runtime.NODEJS_18_X,
+        runtime: Runtime.NODEJS_20_X,
         environmentEncryption: new Key(
           this,
           "InvoicePostProcessingFunctionKey",
@@ -126,7 +126,7 @@ export class InvoiceStateMachine extends Construct {
         architecture: Architecture.ARM_64,
         entry: path.join(__dirname, "/../packages/startQueries/index.ts"),
         memorySize: 1024,
-        runtime: Runtime.NODEJS_18_X,
+        runtime: Runtime.NODEJS_20_X,
         environmentEncryption: new Key(this, "StartQueriesFunctionKey", {
           enableKeyRotation: true,
         }),

--- a/source/package-lock.json
+++ b/source/package-lock.json
@@ -8,7 +8,7 @@
       "name": "invoices-to-insights",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "2.59.0",
+        "aws-cdk-lib": "^2.159.1",
         "cdk-nag": "^2.21.75",
         "constructs": "^10.0.0",
         "source-map-support": "^0.5.21"
@@ -19,7 +19,7 @@
       "devDependencies": {
         "@types/jest": "^29.2.4",
         "@types/node": "18.11.15",
-        "aws-cdk": "2.59.0",
+        "aws-cdk": "^2.159.1",
         "esbuild": "^0.17.3",
         "jest": "^29.3.1",
         "ts-jest": "^29.0.3",
@@ -41,19 +41,55 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.49",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.49.tgz",
-      "integrity": "sha512-Qd5bdLlC/sphWQQPNn7etKXWCh+fij7DWxtkIwvhhZ+LM6UEApGLS8sBLBQcRO2ZQdEuNb+zeClUy+3DNojfeg=="
+      "version": "2.2.204",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.204.tgz",
+      "integrity": "sha512-cm7aZKIubmBAS5IOkGEmh3h8VlKeOsNlLJJ39MnbmGZxXcW7+WaqIS7S4Z3YLKrs6EVQnrP8XQ2kt3cjkqKIJg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.1.tgz",
-      "integrity": "sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
+      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg==",
+      "license": "Apache-2.0"
     },
-    "node_modules/@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.38.tgz",
-      "integrity": "sha512-BBwAjORhuUkTGO3CxGS5Evcp5n20h9v06Sftn2R1DuSm8zIoUlPsNlI1HUk8XqYuoEI4aD7IKRQBLglv09ciJQ=="
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
+      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "38.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-38.0.1.tgz",
+      "integrity": "sha512-KvPe+NMWAulfNVwY7jenFhzhuLhLqJ/OPy5jx7wUstbjnYnjRVLpUHPU3yCjXFE0J8cuJVdx95BJ4rOs66Pi9w==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.4.1",
+        "semver": "^7.6.3"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.6.3",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
@@ -163,31 +199,6 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
       "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
       "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
-      "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/template": "^7.18.10",
-        "@babel/types": "^7.19.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.18.6"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1406,7 +1417,6 @@
         "@babel/types": "^7.0.0"
       }
     },
-
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -1572,10 +1582,11 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.59.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.59.0.tgz",
-      "integrity": "sha512-5xKh+nC6wLsjYGwA+YYbX9ZonJLYmthxSZy8pK/Bm9rL2mFpnMKvQZJz67L6ghOt1XumoB1vZbIhptln68jTuw==",
+      "version": "2.160.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.160.0.tgz",
+      "integrity": "sha512-JquccawrU2dp0cS80my65oLLNRUJZflKRKIRSVjQ1A9W4bNns/xhSqaVlL41NAsGSYBWxCzzWHrV3yOFShU87A==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
       },
@@ -1587,9 +1598,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.59.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.59.0.tgz",
-      "integrity": "sha512-FT6QRsou8TibQcz/TqI3rEkB9EBVF5Om5lv9MXz/5qiKehWRbKZVX0I0l/SSAvGSmdTU5Pfr+WRBTk51oNMAdw==",
+      "version": "2.160.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.160.0.tgz",
+      "integrity": "sha512-HJvn1lKmyZk1i56j4sgOddRfoDto9L/INgXSWmLzDdnMdMQWRvB/dbPQPrF1voVN26UKmrNdH9Irr0soMD5B1A==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1599,20 +1610,26 @@
         "minimatch",
         "punycode",
         "semver",
-        "yaml"
+        "table",
+        "yaml",
+        "mime-types"
       ],
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.30",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.38",
+        "@aws-cdk/asset-awscli-v1": "^2.2.202",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
+        "@aws-cdk/cloud-assembly-schema": "^38.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^9.1.0",
-        "ignore": "^5.2.1",
+        "fs-extra": "^11.2.0",
+        "ignore": "^5.3.2",
         "jsonschema": "^1.4.1",
+        "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
-        "punycode": "^2.1.1",
-        "semver": "^7.3.8",
+        "punycode": "^2.3.1",
+        "semver": "^7.6.3",
+        "table": "^6.8.2",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -1627,12 +1644,49 @@
       "inBundle": true,
       "license": "Apache-2.0"
     },
-    "node_modules/aws-cdk-lib/node_modules/at-least-node": {
-      "version": "1.0.0",
+    "node_modules/aws-cdk-lib/node_modules/ajv": {
+      "version": "8.17.1",
       "inBundle": true,
-      "license": "ISC",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
@@ -1657,37 +1711,80 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/color-convert": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-name": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/aws-cdk-lib/node_modules/concat-map": {
       "version": "0.0.1",
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "9.1.0",
+      "version": "11.2.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.14"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
-      "version": "4.2.10",
+      "version": "4.2.11",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.2.1",
+      "version": "5.3.2",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
       "version": "6.1.0",
@@ -1708,15 +1805,28 @@
         "node": "*"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/lru-cache": {
-      "version": "6.0.0",
+    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+      "version": "4.4.2",
       "inBundle": true,
-      "license": "ISC",
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "inBundle": true,
+      "license": "MIT",
       "dependencies": {
-        "yallist": "^4.0.0"
+        "mime-db": "1.52.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">= 0.6"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
@@ -1731,20 +1841,25 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.1.1",
+      "version": "2.3.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.3.8",
+      "version": "7.6.3",
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1752,18 +1867,68 @@
         "node": ">=10"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/string-width": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/table": {
+      "version": "6.8.2",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }
-    },
-    "node_modules/aws-cdk-lib/node_modules/yallist": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
       "version": "1.10.2",
@@ -2453,15 +2618,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/graceful-fs": {
@@ -4320,19 +4476,38 @@
       }
     },
     "@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.49",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.49.tgz",
-      "integrity": "sha512-Qd5bdLlC/sphWQQPNn7etKXWCh+fij7DWxtkIwvhhZ+LM6UEApGLS8sBLBQcRO2ZQdEuNb+zeClUy+3DNojfeg=="
+      "version": "2.2.204",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.204.tgz",
+      "integrity": "sha512-cm7aZKIubmBAS5IOkGEmh3h8VlKeOsNlLJJ39MnbmGZxXcW7+WaqIS7S4Z3YLKrs6EVQnrP8XQ2kt3cjkqKIJg=="
     },
     "@aws-cdk/asset-kubectl-v20": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.1.tgz",
-      "integrity": "sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
+      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
     },
-    "@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.38.tgz",
-      "integrity": "sha512-BBwAjORhuUkTGO3CxGS5Evcp5n20h9v06Sftn2R1DuSm8zIoUlPsNlI1HUk8XqYuoEI4aD7IKRQBLglv09ciJQ=="
+    "@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
+      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A=="
+    },
+    "@aws-cdk/cloud-assembly-schema": {
+      "version": "38.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-38.0.1.tgz",
+      "integrity": "sha512-KvPe+NMWAulfNVwY7jenFhzhuLhLqJ/OPy5jx7wUstbjnYnjRVLpUHPU3yCjXFE0J8cuJVdx95BJ4rOs66Pi9w==",
+      "requires": {
+        "jsonschema": "^1.4.1",
+        "semver": "^7.6.3"
+      },
+      "dependencies": {
+        "jsonschema": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "semver": {
+          "version": "7.6.3",
+          "bundled": true
+        }
+      }
     },
     "@babel/code-frame": {
       "version": "7.18.6",
@@ -4421,25 +4596,6 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
       "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
       "dev": true
-    },
-    "@babel/helper-function-name": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
-      "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
-      "dev": true,
-      "requires": {
-        "@babel/template": "^7.18.10",
-        "@babel/types": "^7.19.0"
-      }
-    },
-    "@babel/helper-hoist-variables": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.18.6"
-      }
     },
     "@babel/helper-module-imports": {
       "version": "7.18.6",
@@ -5415,30 +5571,33 @@
       }
     },
     "aws-cdk": {
-      "version": "2.59.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.59.0.tgz",
-      "integrity": "sha512-5xKh+nC6wLsjYGwA+YYbX9ZonJLYmthxSZy8pK/Bm9rL2mFpnMKvQZJz67L6ghOt1XumoB1vZbIhptln68jTuw==",
+      "version": "2.160.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.160.0.tgz",
+      "integrity": "sha512-JquccawrU2dp0cS80my65oLLNRUJZflKRKIRSVjQ1A9W4bNns/xhSqaVlL41NAsGSYBWxCzzWHrV3yOFShU87A==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2"
       }
     },
     "aws-cdk-lib": {
-      "version": "2.59.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.59.0.tgz",
-      "integrity": "sha512-FT6QRsou8TibQcz/TqI3rEkB9EBVF5Om5lv9MXz/5qiKehWRbKZVX0I0l/SSAvGSmdTU5Pfr+WRBTk51oNMAdw==",
+      "version": "2.160.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.160.0.tgz",
+      "integrity": "sha512-HJvn1lKmyZk1i56j4sgOddRfoDto9L/INgXSWmLzDdnMdMQWRvB/dbPQPrF1voVN26UKmrNdH9Irr0soMD5B1A==",
       "requires": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.30",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.38",
+        "@aws-cdk/asset-awscli-v1": "^2.2.202",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
+        "@aws-cdk/cloud-assembly-schema": "^38.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^9.1.0",
-        "ignore": "^5.2.1",
+        "fs-extra": "^11.2.0",
+        "ignore": "^5.3.2",
         "jsonschema": "^1.4.1",
+        "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
-        "punycode": "^2.1.1",
-        "semver": "^7.3.8",
+        "punycode": "^2.3.1",
+        "semver": "^7.6.3",
+        "table": "^6.8.2",
         "yaml": "1.10.2"
       },
       "dependencies": {
@@ -5446,8 +5605,29 @@
           "version": "1.0.2",
           "bundled": true
         },
-        "at-least-node": {
-          "version": "1.0.0",
+        "ajv": {
+          "version": "8.17.1",
+          "bundled": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "fast-uri": "^3.0.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "bundled": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "astral-regex": {
+          "version": "2.0.0",
           "bundled": true
         },
         "balanced-match": {
@@ -5466,26 +5646,56 @@
           "version": "1.6.3",
           "bundled": true
         },
+        "color-convert": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "bundled": true
+        },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true
         },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "bundled": true
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "bundled": true
+        },
+        "fast-uri": {
+          "version": "3.0.1",
+          "bundled": true
+        },
         "fs-extra": {
-          "version": "9.1.0",
+          "version": "11.2.0",
           "bundled": true,
           "requires": {
-            "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
         },
         "graceful-fs": {
-          "version": "4.2.10",
+          "version": "4.2.11",
           "bundled": true
         },
         "ignore": {
-          "version": "5.2.1",
+          "version": "5.3.2",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
           "bundled": true
         },
         "jsonfile": {
@@ -5500,11 +5710,19 @@
           "version": "1.4.1",
           "bundled": true
         },
-        "lru-cache": {
-          "version": "6.0.0",
+        "lodash.truncate": {
+          "version": "4.4.2",
+          "bundled": true
+        },
+        "mime-db": {
+          "version": "1.52.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.35",
           "bundled": true,
           "requires": {
-            "yallist": "^4.0.0"
+            "mime-db": "1.52.0"
           }
         },
         "minimatch": {
@@ -5515,22 +5733,55 @@
           }
         },
         "punycode": {
-          "version": "2.1.1",
+          "version": "2.3.1",
+          "bundled": true
+        },
+        "require-from-string": {
+          "version": "2.0.2",
           "bundled": true
         },
         "semver": {
-          "version": "7.3.8",
+          "version": "7.6.3",
+          "bundled": true
+        },
+        "slice-ansi": {
+          "version": "4.0.0",
           "bundled": true,
           "requires": {
-            "lru-cache": "^6.0.0"
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "bundled": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "table": {
+          "version": "6.8.2",
+          "bundled": true,
+          "requires": {
+            "ajv": "^8.0.1",
+            "lodash.truncate": "^4.4.2",
+            "slice-ansi": "^4.0.0",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1"
           }
         },
         "universalify": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "yallist": {
-          "version": "4.0.0",
+          "version": "2.0.1",
           "bundled": true
         },
         "yaml": {
@@ -6032,12 +6283,6 @@
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
-    },
-    "globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/source/package.json
+++ b/source/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@types/jest": "^29.2.4",
     "@types/node": "18.11.15",
-    "aws-cdk": "2.59.0",
+    "aws-cdk": "^2.159.1",
     "esbuild": "^0.17.3",
     "jest": "^29.3.1",
     "ts-jest": "^29.0.3",
@@ -21,7 +21,7 @@
     "typescript": "~4.9.4"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.59.0",
+    "aws-cdk-lib": "^2.159.1",
     "cdk-nag": "^2.21.75",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"

--- a/source/packages/invoicePostProcessing/index.ts
+++ b/source/packages/invoicePostProcessing/index.ts
@@ -111,7 +111,7 @@ const extractValuesFromAnalyzeExpense = (
           (a.ValueDetection?.Confidence || 0)
       );
     return (
-      vendorNameResultsSortedByConfidence[0].ValueDetection?.Text || "undefined"
+      vendorNameResultsSortedByConfidence[0]?.ValueDetection?.Text || "undefined"
     );
   };
 


### PR DESCRIPTION
We tried to deploy this, and deploys were failing with an 'Unsupported runtime' error related to the `CustomS3AutoDeleteObjectsCustomResourceProviderHandler` resource. 

That resource is created by the `autodeleteObjects = true` property on the `InvoicesBucket`. Older versions of CDK implement the Lambda in Node 14.x, which is no longer a support runtime.

The fix is to bump the CDK version. I have bumped it to the most recent version as of this ticket. I have also changed the version range to require any 2.x version of `aws-cdk` and `aws-cdk-lib`.

The invoice I used caused an error with an empty list in  `getMostConfidentResultBySummaryFieldsType`. I added an optional chaining operator to deal with this; not sure if that was caused by the CDK version bump or my particular invoice.